### PR TITLE
Fix offsets for custom colors (version 1.1.0 support)

### DIFF
--- a/customcolors/main.c
+++ b/customcolors/main.c
@@ -24,7 +24,7 @@ typedef struct __attribute__((__packed__)) {
     float a;
 } Color;
 
-MAKE_HOOK(get_colorA, 0x104B6C8, Color, void* self)
+MAKE_HOOK(get_colorA, 0x130C350, Color, void* self)
 {
     Color color = {0};
     color.r = left_r;
@@ -34,7 +34,7 @@ MAKE_HOOK(get_colorA, 0x104B6C8, Color, void* self)
     return color;
 }
 
-MAKE_HOOK(get_colorB, 0x104B820, Color, void* self)
+MAKE_HOOK(get_colorB, 0x130C4A8, Color, void* self)
 {
     Color color = {0};
     color.r = right_r;
@@ -45,7 +45,7 @@ MAKE_HOOK(get_colorB, 0x104B820, Color, void* self)
 }
 
 // bg colors
-MAKE_HOOK(get_color, 0x10E960C, Color, void* self)
+MAKE_HOOK(get_color, 0x12DC59C, Color, void* self)
 {
     Color color = get_color(self);
     if (fabs(color.r - 0.188235f) < 0.001 && fabs(color.g - 0.619608f) < 0.001 && color.b == 1.0f) {


### PR DESCRIPTION
Untested, but reliant on the fact that leo's mod worked before. If it did, then this should work properly for version 1.1.0, otherwise, there could be a bunch of issues that I haven't spotted yet.
I found these offsets by reverting versions until v1.0.1, where I had an IL2CPP Dump that had offsets that matched the ones that I replaced. I then looked at which methods they corresponded to and found the proper offsets in the 1.1.0 IL2CPP Dump.
On an unrelated note, I seem to be having problems with hooks not firing, as well as concurrent mod loading, but I don't know enough about what could be going wrong to create an issue just yet.
Please contact me on Discord at Sc2ad#8836, or in the #quest-mod-dev channel.
Hooray for emulamer's modding progress!